### PR TITLE
Bugfix: OAuth should open in an external browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.3.1+3]
+- fix: OAuth authentication page should open in an external browser
+
 ## [0.3.1+2]
 - chore: update supabase package [v0.3.4+1](https://github.com/supabase-community/supabase-dart/blob/main/CHANGELOG.md#0341)
 

--- a/lib/src/supabase_auth.dart
+++ b/lib/src/supabase_auth.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
-import 'package:supabase_flutter/supabase_flutter.dart';
 
+import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// SupabaseAuth
 class SupabaseAuth {
   SupabaseAuth._();
+
   static final SupabaseAuth _instance = SupabaseAuth._();
 
   bool _initialized = false;
@@ -167,7 +168,11 @@ extension GoTrueClientSignInProvider on GoTrueClient {
       options: options,
     );
     final url = Uri.parse(res.url!);
-    final result = await launchUrl(url, webOnlyWindowName: '_self');
+    final result = await launchUrl(
+      url,
+      mode: LaunchMode.externalApplication,
+      webOnlyWindowName: '_self',
+    );
     return result;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_flutter
 description: Flutter integration for Supabase. This package makes it simple for developers to build secure and scalable products.
-version: 0.3.1+2
+version: 0.3.1+3
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-flutter'
 


### PR DESCRIPTION
OAuth is now blocked inside embedded browsers by Facebook, Google and others. Authentication page should always be opened in an external browser. This fix addresses that.