### PR TITLE
chore: publish v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## [0.3.2]
+## [0.3.3]
 - feat: update supabase package [v0.3.6](https://github.com/supabase-community/supabase-dart/blob/main/CHANGELOG.md#036)
+
+## [0.3.2]
 - chore: add basic example codes on readme.md
 
 ## [0.3.1+3]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_flutter
 description: Flutter integration for Supabase. This package makes it simple for developers to build secure and scalable products.
-version: 0.3.2
+version: 0.3.3
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-flutter'
 
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   hive: ^2.2.1
   hive_flutter: ^1.1.0
-  supabase: ^0.3.4+1
+  supabase: ^0.3.6
   uni_links: ^0.5.1
   url_launcher: ^6.1.2
 


### PR DESCRIPTION
In the previous version, I had made a mistake, and hadn't updated the underlying `supabase-dart` version. This one corrects that mistake.